### PR TITLE
Update character limit for message text

### DIFF
--- a/Application/src/RazorPagesTestSample/Data/Message.cs
+++ b/Application/src/RazorPagesTestSample/Data/Message.cs
@@ -9,7 +9,7 @@ namespace RazorPagesTestSample.Data
 
         [Required]
         [DataType(DataType.Text)]
-        [StringLength(200, ErrorMessage = "There's a 200 character limit on messages. Please shorten your message.")]
+        [StringLength(250, ErrorMessage = "There's a 250 character limit on messages. Please shorten your message.")]
         public string Text { get; set; }
     }
     #endregion


### PR DESCRIPTION
Changed maximum message size from 200 to 250 characters to reflect customer demand for larger messages.